### PR TITLE
add specific checkpoints to download from guided-diffusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ conda activate zecon
 Our source code relies on [blended diffusion](https://github.com/omriav/blended-diffusion).
 
 ### Pre-trained model
-Download the model weights trained on [imagenet](https://github.com/openai/guided-diffusion) and [ffhq](https://github.com/jychoi118/ilvr_adm) dataset, respectively.
+Download the model weights trained on [imagenet](https://github.com/openai/guided-diffusion) (256x256_diffusion_uncond.pt) and [ffhq](https://github.com/jychoi118/ilvr_adm) (ffhq_baseline.pt) dataset, respectively.
 
 Create a folder ```'./ckpt/'``` and then place the downloaded weights into the folder.
 


### PR DESCRIPTION
As mentioned here: `optimization/image_editor_zecon.py`, the script looks for imagenet's `256x256_diffusion_uncond.pt` checkpoint and ffhq's `ffhq_baseline.pt` checkpoint in the `ckpt` directory. Thus, updating README with these specific checkpoints would help.